### PR TITLE
Update SDK documentation for pairing code based auth

### DIFF
--- a/sdk/index.md
+++ b/sdk/index.md
@@ -22,7 +22,7 @@ If you're interested in becoming one, please reach out to [sdk@soundtrackyourbra
 All applications using the SDK must adhere to the Soundtrack Terms & Conditions. Certification is required before launch.
 
 ### API
-The SDK provides C header files, exposing an API called SPlayer API. It enables you to can do basic playback control and interface to the audio output of your choice.
+The SDK provides C header files, exposing an API called SPlayer API. It enables you to do basic playback control and interface to the audio output of your choice.
 In its most basic form you'll get raw PCM samples out, but there are examples provided for common platforms for how to interface with the OS audio output.
 
 The player itself is provided as a single shared library, built by us with a toolchain you provide. API additions can be made without the need for recompile from your side.

--- a/sdk/index.md
+++ b/sdk/index.md
@@ -15,149 +15,75 @@
 
 ## Introduction
 
-The Soundtrack SDK enables you to build support for Soundtrack on your platform. By combining expert curation and world-class tech, Soundtrack Your Brand provides a beautiful all-in-one solution for streaming music to stores, hotels, restaurants, and other commercial settings.
+The Soundtrack SDK makes it possible to play music from Soundtrack on your platform. 
+It is available for selected partners with potential for over 5000 locations. 
+If you're interested in becoming one, please reach out to [sdk@soundtrackyourbrand.com](mailto:sdk@soundtrackyourbrand.com).
 
-The SDK is available for selected partners. If you're interested in becoming one, please reach out to sdk@soundtrackyourbrand.com (applications currently open for opportunities of more than 5000 locations).
-
-This page contains the documentation for the SDK. In order to use it, you will need our latest build (which we will send to you).
-
-Soundtrack SDK is the package containing all code and documentation needed for you to get started. Splayer API is the local API within the SDK, used for initiating and controlling playback.
-
-Unless anything else is communicated by Soundtrack, the application shall be named "Soundtrack Player".
+All applications using the SDK must adhere to the Soundtrack Terms & Conditions. Certification is required before launch.
 
 ### Api
-* Provided as a single shared library, built with a toolchain provided by a partner and with no external dependencies.
-* Few entry points, which means faster load times and simple mapping both for dynamic and static linking.
-* Extendable API without the need to recompile (unless there are breaking changes).
-* Callbacks for audio so you can control your hardware specific needs.
+The SDK provides C header files, exposing an API called SPlayer API. It enables you to can do basic playback control and interface to the audio output of your choice.
+In its most basic form you'll get raw PCM samples out, but there are examples provided for common platforms for how to interface with the OS audio output.
 
-#### Available actions
-* Create and free an Splayer API context.
-* Exit the player gracefully (after the next song).
-* Player control (play, pause, skip track, set volume).
-* Get error list.
+The player itself is provided as a single shared library, built by us with a toolchain you provide. Api additions can be made without the need for recompile from your side.
 
-### Responsibilities
-* Soundtrack is responsible for the binary and header file (e.g. libsplayer-x.so and splayerapi-x.h).
-* Splayer communicates with Soundtrack's infrastructure and delivers sound buffers (e.g. PCM data).
-* Partner is responsible for all the parts concerning the executable, the actual playback (eg. ALSA).
-* Soundtrack provides source code examples as-is and it's the Partners responsibility to make them work.
-* Partner can use any part of the source code example, change and modify them, except splayerapi-x.h
-* Partner is responsible to check with Soundtrack's infrastructure every 15 minutes to see if new releases are available.
-* Partner is responsible for providing a toolchain that supports a C++ standard that is at most 5 years old at any given time now and in the future.
+#### Available Actions
+* Create and free an SPlayer API context.
+* Exit the player gracefully (after current song has ended).
+* Authentication
+* Playback controls (play, pause, skip track, set volume).
+* Retrieve errors.
 
 ### Requirements
 * A POSIX API compatible OS, that supports TCP sockets, and threads.
 * At least 64 MB free RAM for the player to operate in.
 * A reasonably strong CPU that could handle our parallel encryption, decoding and digital signal processing.
 * A minimum of 4 GB of storage used for offline music and data storage. 8 GB is recommended.
-* Partner needs to provide a C++14 capable cross compiler toolchain, and compiler options that we can build our library in a x86-64 linux docker container.
+* You need to provide a C++14 capable cross-compiler toolchain and compiler options, so we can build our library in an x86-64 linux docker container.
 * An onboard RTC with backup battery. In case of a power loss, we cannot play audio until we have a valid system time due to our scheduling, and licensing constraints.
 
-### Communication
-* Main communication channel with Soundtrack is a shared Slack channel in Soundtracks workspace.
-* Partner is responsible to provide a list of relevant people to be invited.
+### Soundtrack Responsibilities
+* SPlayer binary and header files (e.g. libsplayer-x.so and splayerapi-x.h).
+* Backend infrastructure used by SPlayer.
 
-## Changelog
-
-Detailed changelog can be found in the SDK package.
-
-Date | Version | Changes | Included APIs
---- | --- | --- | ---
-Q4, 2017 | 1 | First draft including basic functionality. | splayerapi v1
-Q2, 2018 | 2 | Moved controls to a separate API. Clarified examples. | splayerapi v2, splayerapi_control v1
-Q4, 2018 | 3 | Major/minor versioning. New metadata API. Some config variables renamed for clarity. | splayerapi v3, splayer_controls_api v2, splayer_troubles_api v1, splayer_audio_api v1, splayer_metadata_api v1
-Q2, 2020 | 4 | Updated metadata API, config variable to turn off cover art download. Config to turn off core-dumps. | splayerapi v4, splayer_controls_api v4, splayer_troubles_api v2, splayer_audio_api v1, splayer_metadata_api v2
+### Partner Responsibilities
+* Application lifecycle.
+* Application monitoring.
+* Audio processing of the SPlayer output.
+* All source code except for splayerapi-x.h.
+* Library update mechanism.
+* Updating the toolchain to make sure it supports a C++ standard that is at most 5 years old at any given time now and in the future.
 
 ## Getting started
 
-### Prerequisites
-Make sure that you have:
-* Your vendor secret (provided to you by Soundtrack).
-* Your Partner API credentials (provided to you by Soundtrack).
-* Access to Soundtrack. Sign up at soundtrackyourbrand.com.
-
-All applications must be in line with the terms & conditions and be certified by Soundtrack (see certification criteria further down on this page).
-
 ### What's in the package?
-* Header files for Splayer API and ALSA implementation example
+* Header files for Splayer API
 * Shared library for Splayer API
 * Example implementations for audio output via ALSA or Darwin
-* Example source code using ALSA or Darwin
 * Example source code using the update service to fetch latest shared library
 
-Note: The package can't be found on this page. It will be sent to you by Soundtrack. A static library version can be provided. It is not included by default due to the increase in size of the package
+You'll find the link for it here: https://builds.soundtrackyourbrand.com/remote/splayer-ubuntu/latest
+Look for the splayerapi-1-v4 package. Inside it, there are the headers needed to interface to the library as well as some example applications.
 
-### Soundtrack - Overview
-We highly recommend that you play around with your Soundtrack account so you get an overview of the product prior to using the API. All guides and frequently asked questions regarding Soundtrack can be found on our help pages.
+In order for you to get a player up and running as quickly as possible, use the pairing code option available in the auth api. There is an example of how to use it in the example_auth.c file.
+Unfortunately, we haven't yet finished updating the official documentation over at https://developer.soundtrackyourbrand.com/sdk/ with this feature. But I believe you can figure it out using the example and the function descriptions in the headers.
 
-It’s extra important that you understand the hierarchy, where one **account** (e.g. “Ludwig's Burgers”) can have multiple **locations** (e.g. “Flagship restaurant, Stockholm”) which in turn can have multiple **sound zones** (e.g. “Bar”, “Restaurant area”, “Staff room”).
-
-Each sound zone can only have one **device**. Soundtrack supports multiple device types (see our help pages to see which ones). The rationale for having multiple sound zones is that you want different music in different parts of the same location. If you want the same music everywhere in the same location you’ll only need one device and then distribute the music with your audio system.
-
-### Create a device
-
-Before you can run an application using the SDK, you must create a device using the Partner API. This device will be unique and needs to be paired to a sound zone. A device can only be paired with one sound zone at a time. The Partner API is a GraphQL API and you can run the following to create a device. Note: you need your Partner API credentials to do this step. It only needs to be done once since the pairing code does not change.
-
-1. Go to https://partner.soundtrackyourbrand.com/api/explore (this is just an explore tool, you should of course implement this code where you find it suitable)
-2. Add the Authorization header. In the “Value” field, write “Basic \<your_credentials\>” where \<your_credentials\> are the Partner API credentials that you should have received from Soundtrack. Ensure that you copy the full base64-token including the == on the end
-
-Example:
-```
-Authorization: base64encode(client_id:client_secret)
-```
-3. Enter a GraphQL query in the top box
-```
-mutation PartnerCodeCreator($input:GeneratePairingCodesInput!){
-    generatePairingCodes(input: $input) {
-        codes {
-            pairingCode
-        }
-    }
-}
-```
-4. Include the query variables
-```
-{
-    "input": {
-        "description":"ARM64",
-        "deviceType": "EMBEDDED",
-        "label": "Partnername M324",
-        "hardwareIds": ["partner_id_ab12"]
-    }
-}
-```
- * Change the `description` to add  a description of the specific hardware/platform, so we can distinguish among your devices in case there are any differences in hardware/platform or you come up with a new generation etc.
- * Set `deviceType` to `EMBEDDED` (currently not optional)
- * Change the `label` to the name of your product. This will be shown to users at business.soundtrackyourbrand.com.
- * Change the `hardwareIds` entry to the hardware_id of your choice. See "Authentication & Pairing" for more info
-
-
-5. Run the query and you should get a pairing code as output. You will need this code to pair the created device with a specific sound zone later.
-6. Write down the hardware_id that you chose (in the example ‘partner_id_ab12’). Write down the pairing code that was output when you ran the query. You can rerun the query if you need to. Supplying an existing hardware id will always return the same pairing code.
-
-### Pairing a device with a sound zone
-1. Open [https://business.soundtrackyourbrand.com](https://business.soundtrackyourbrand.com).
-2. Navigate to “zones”.
-3. Use an existing zone or create a new one.
-4. Click your zone and pair the device using the "Hardware" tab.
-5. Enter the Pairing Code that you got when creating a device.
-6. The device should now be paired with this sound zone.
+Let us know if you have any questions!
 
 ### Building and running the example code
 1. Open the /src folder. There are several examples showcasing some basic setup of a player application.
-3. Edit the example files with the hardware_id you created in the “Create a device” section (“partner_id_ab12” in above example).
-4. Supply the vendor secret to the application. This can be done in a few different ways:
+1. Edit the example files with the hardware_id you created in the “Create a device” section (“partner_id_ab12” in above example).
+1. Supply the vendor secret to the application. This can be done in a few different ways:
  * Set the value directly in vendor_secret
  * Set `-DVENDOR_SECRET=xxxx` when building with cmake
  * Add the vendor secret directly in the CMakeList.txt file
  ```c
  add_definitions(-DVENDOR_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
  ```
-5. Build the project using cmake
-6. There will now be several example targets in the build root folder
-7. Run the example executable (eg. libsplayer_simple)
-8. There should be some console output and music should start playing shortly
+1. Build the project using cmake
+1. There will now be several example targets in the build root folder
+1. Run the example executable (eg. libsplayer_simple)
+1. There should be some console output and music should start playing shortly
 
 ```c
 libsplayer_alsa

--- a/sdk/index.md
+++ b/sdk/index.md
@@ -21,11 +21,11 @@ If you're interested in becoming one, please reach out to [sdk@soundtrackyourbra
 
 All applications using the SDK must adhere to the Soundtrack Terms & Conditions. Certification is required before launch.
 
-### Api
+### API
 The SDK provides C header files, exposing an API called SPlayer API. It enables you to can do basic playback control and interface to the audio output of your choice.
 In its most basic form you'll get raw PCM samples out, but there are examples provided for common platforms for how to interface with the OS audio output.
 
-The player itself is provided as a single shared library, built by us with a toolchain you provide. Api additions can be made without the need for recompile from your side.
+The player itself is provided as a single shared library, built by us with a toolchain you provide. API additions can be made without the need for recompile from your side.
 
 #### Available Actions
 * Create and free an SPlayer API context.
@@ -68,44 +68,48 @@ Look for the splayerapi-1-v4 package. Inside it, there are the headers needed to
 In order for you to get a player up and running as quickly as possible, use the pairing code option available in the auth api. There is an example of how to use it in the example_auth.c file.
 Unfortunately, we haven't yet finished updating the official documentation over at https://developer.soundtrackyourbrand.com/sdk/ with this feature. But I believe you can figure it out using the example and the function descriptions in the headers.
 
-Let us know if you have any questions!
+It’s extra important that you understand the hierarchy, where one **account** (e.g. “Ludwig's Burgers”) can have multiple **locations** (e.g. “Flagship restaurant, Stockholm”) which in turn can have multiple **sound zones** (e.g. “Bar”, “Restaurant area”, “Staff room”).
 
-### Building and running the example code
+Each sound zone can only have one **device**. Soundtrack supports multiple device types (see our help pages to see which ones). The rationale for having multiple sound zones is that you want different music in different parts of the same location. If you want the same music everywhere in the same location you’ll only need one device and then distribute the music with your audio system.
+
+## Pairing a device with a sound zone
+To initiate streaming, your application must first be paired with a specific sound zone within a Soundtrack location. This pairing process utilizes a unique pairing code, generated on demand by Soundtrack.
+Once paired, a unique Device ID will be returned that can be used when checking for SDK updates later.
+
+### Obtaining a Pairing Code
+There are two primary methods for obtaining a pairing code; Redirect and Callback or Manual Entry.
+
+#### Redirect and Callback (Preferred):
+
+This method provides the smoothest user experience by eliminating manual entry.
+
+1. Your application initiates a redirect to the following URL:
+   `http://business.soundtrackyourbrand.com/connect/generic?redirect=<REDIRECT_URL>`
+   Replace `<REDIRECT_URL>` with the URL of your application that will handle the callback. This URL must be accessible by the device that is used for the pairing flow.
+1. The user logs in to their Soundtrack account and selects the desired sound zone.
+1. Soundtrack redirects the user back to your specified REDIRECT_URL with the pairing code appended as a query parameter: `<REDIRECT_URL>?code=<CODE>`
+1. Your application can then extract the code parameter and programmatically provide it to the SDK. See `example_auth.c` in the SDK package for a proof-of-concept using this method.
+
+Important Considerations:
+* When using the redirect method, ensure your application can handle URL redirects and retrieve parameters from the callback URL.
+* Clearly communicate the redirect process to the user to avoid confusion.
+
+#### Manual Entry:
+
+1. The user logs in to their Soundtrack account through the [Soundtrack web application](https://business.soundtrackyourbrand.com).
+1. They navigate to the desired sound zone and generate a pairing code by selecting `pair`.
+1. A pairing code will be generated and displayed on the page.
+1. The user manually enters this code into your application's interface.
+
+## Building and running the example code
 1. Open the /src folder. There are several examples showcasing some basic setup of a player application.
-1. Edit the example files with the hardware_id you created in the “Create a device” section (“partner_id_ab12” in above example).
-1. Supply the vendor secret to the application. This can be done in a few different ways:
- * Set the value directly in vendor_secret
- * Set `-DVENDOR_SECRET=xxxx` when building with cmake
- * Add the vendor secret directly in the CMakeList.txt file
- ```c
- add_definitions(-DVENDOR_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
- ```
 1. Build the project using cmake
 1. There will now be several example targets in the build root folder
-1. Run the example executable (eg. libsplayer_simple)
+1. Run the example executable (eg. libsplayer_simple). When running an example for the first time, provide the pairing code (see above) as the first argument to the application.
 1. There should be some console output and music should start playing shortly
 
-```c
-libsplayer_alsa
-is_playing() = false
-
-
-alsa_open samp: 44100 channels: 2
-Alsa initialized, buffer_size: 88200 period_size: 22050
-Couldn't find PCM 'PCM' volume control.
-alsa_audio_impl::audio_pause: 0
-  9 21:56:36 tyson                    warn             job.cpp:161  Slow timer, seconds: 0.052278248003858607, context: "from: dsp.cpp:344 schedule_setup"
- alsa_audio_impl::audio_pause: 0
-ERROR: EBADFD: Let's prepare alsa again
-snd_pcm_prepare returned 0
-```
-
 ## Reference implementation
-In the package distributed by SYB, you will find an array of example implementations. Feel free to modify as you wish.
-
-## Authentication & Pairing
-
-Splayer API is only aware of Vendor Hardware ID, which is something that you as a vendor chose, and a Vendor Secret that you will get from Soundtrack. The hardware ID is used to generate the Device ID in the Partner API (see Create a Device above). The reason Soundtrack Device ID's are used for pairing is because they are guaranteed to be unique, even though two vendors might have the same Vendor Hardware ID for two different devices. This way we avoid name clashes for devices.
+In the package distributed by Soundtrack, you will find an array of example implementations. Feel free to modify as you wish.
 
 ## Upgrade and provisioning
 Splayer API is provisioned by Soundtrack's build systems with rollout limited to a certain percent of all devices, or at a certain time of day considering local time zone of the device. Below are two different endpoints to use to retrieve the latest version of Splayer API for two different platforms (Android ARM 64 bit, Ubuntu 16.04 32 bit).
@@ -118,11 +122,11 @@ The template is basically:
 
 ```json
 {
-"id": "QnVpbGQsLDFsZ2g1bW1uNnJrLw..",
-"version": "48.17-308",
-"link": "https://download.api.soundtrackyourbrand.com/ci-releases/splayer-x86_64/libsplayer-1-48.17-308-splayer-x86_64.so",
-"checksum": "9e12bb0ded21711ea1c666dc776b2751febcc01f",
-"platform": "splayer-x86_64"
+  "id": "QnVpbGQsLDFsZ2g1bW1uNnJrLw..",
+  "version": "48.17-308",
+  "link": "https://download.api.soundtrackyourbrand.com/ci-releases/splayer-x86_64/libsplayer-1-48.17-308-splayer-x86_64.so",
+  "checksum": "9e12bb0ded21711ea1c666dc776b2751febcc01f",
+  "platform": "splayer-x86_64"
 }
 ```
 
@@ -130,7 +134,12 @@ The two important fields are version and link, you can disregard all other field
 
 The checksum is a sha1 hash of the file in the link. Make sure to verify the checksum matches for security and reliability reasons.
 
-To get provisioning working you need to send three HTTP headers. Basically each device sends a Vendor Hardware ID as described above and a Device Vendor ID. In the example below the Vendor Hardware ID is `28cfe91fcc6d`.
+To get provisioning working you need to send three HTTP headers containing:
+* `X-Device-Key-0` - always with value `eth0`.
+* `X-Device-Vendor` - Vendor Hardware ID, will be provided to you by Soundtrack.
+* `X-Device-Id-0` - Device ID. Available once the device is paired. In the example below the Device ID is `28cfe91fcc6d`. If not paired, omit this header.
+
+If the device is not yet paired, then no Device ID is available yet.
 
 ```
 X-Device-Key-0:eth0
@@ -158,7 +167,7 @@ The application built is to be approved by Soundtrack and shall at all times adh
 This section describes the release management of the player library that we send out once a quarter. Note, that this update does not refer to the SDK itself with updated API, which will be communicated when available and backwards compatibility will be kept as long as possible.
 
 ### Release SDK player software
-The SYB releases contain a pre- and full-release. The pre-release is sent out for the purpose of SDK partner testing and the full-release is the the costumer production release. The SYB releases are taking place once every quarter, which is distributed into following months: November, February, May, August. See [SDK Release Calendar](https://calendar.google.com/calendar?cid=c291bmR0cmFja3lvdXJicmFuZC5jb21fZjM5YmpzbWxrZWtncDllazN0dWprZ2NkdWNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) for exact dates.
+The Soundtrack SDK releases contain a pre- and full-release. The pre-release is sent out for the purpose of SDK partner testing and the full-release is the the costumer production release. The Soundtrack SDK releases are taking place once every quarter, which is distributed into following months: November, February, May, August. See [SDK Release Calendar](https://calendar.google.com/calendar?cid=c291bmR0cmFja3lvdXJicmFuZC5jb21fZjM5YmpzbWxrZWtncDllazN0dWprZ2NkdWNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) for exact dates.
 
 #### Pre-release
 Every quarter the pre-release is sent out to the SDK pre-release channel.
@@ -186,7 +195,7 @@ Here's the full [SDK Release Calendar](https://calendar.google.com/calendar?cid=
 
 We support a release for 6 months. Players running versions older than 6 month will stop music playback. One month in advance, the player is deprecated. The time is based on when the software was released.
 
-Here's the full [SYB Deprecation Schedule](https://calendar.google.com/calendar/u/0?cid=Y18yN3B2cThpMWs3b2cwYmhpN2xuYnVjOHFzc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t).
+Here's the full [Soundtrack Deprecation Schedule](https://calendar.google.com/calendar/u/0?cid=Y18yN3B2cThpMWs3b2cwYmhpN2xuYnVjOHFzc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t).
 
 ## Unsupported
 When a player is unsupported, a device error `DEVICE_ERROR_UNSUPPORTED_VERSION` is raised on the zone and authentication will fail with http 426 which results in that the player won't be able to play more music. Mails are being sent out to the concerned customers and it's possible to filter on "Need player update" in Business to find the right players.
@@ -199,14 +208,14 @@ Please note that we can't say which versions will be deprecated when, as that ma
 ## Q&A
 
 ### Older version of libstdc++ and ld.so running on the target.
-Depending on GCC version you might have an older version of libc, libstdc++ and ld. We are running GCC 6.4 and 7.0 in production.
+Depending on GCC version you might have an older version of libc, libstdc++ and ld.
 ```
 ./libSplayer_alsa: /lib/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by libSplayer.so)
 ./libSplayer_alsa: /lib/libstdc++.so.6: version `CXXABI_1.3.8' not found (required by libSplayer.so)
 ./libSplayer_alsa: /lib/libstdc++.so.6: version `GLIBCXX_3.4.19' not found (required by libSplayer.so)
 ./libSplayer_alsa: /lib/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by libSplayer.so)
 ```
-If needed, we can link libstdc++ statically to avoid most of the issues, but your target platform needs a compatible libc.so (glibc). Use the same version of libc and libstdc++ on your target as in the toolchain that you provide us. For Linux, you can create them using Yocto or Buildroot. Be aware that we are using atomics from c++ 11, and some gcc toolchains put these in a separate library called libatomic.so. This library is required on the device for our player to run.
+If needed, we can link libstdc++ statically to avoid most of the issues, but your target platform needs a compatible libc.so. Use the same version of libc and libstdc++ on your target as in the toolchain that you provide us. For Linux, you can create them using Yocto or Buildroot. Be aware that we are using atomics from c++ 11, and some gcc toolchains put these in a separate library called libatomic.so. This library is required on the device for our player to run.
 
 ### Audio stutters
 On some hardware we have seen ALSA defaulting to a very small buffer size. A 44.1Khz two channel PCM stream is 88 200 samples/per second. In the below example that's a context switch 200 times a second (every 5ms). Now a small buffer size is great for low latency, game and sound applications where instant sound feedback is needed on user input. This is not the case for audio streaming. With these small buffers we can't feed ALSA with audio fast enough, so we will get -EPIPE from snd_pcm_writei().
@@ -219,7 +228,7 @@ Alsa initialized, buffer_size: 88200 period_size: 22050
 ```
 
 ### Error codes explanation
-By calling `splayer_get_troubles()` you are able to retrieve a list of SYB internal errors.
+By calling `splayer_get_troubles()` you are able to retrieve a list of Soundtrack internal errors.
 See the example code to know how to do it. These error codes can vary between Splayer versions, but this list is updated whenever a new version is released with changes to them.
 
 Here follows a brief explanation of the current possible errors:
@@ -227,21 +236,21 @@ Here follows a brief explanation of the current possible errors:
 Error name | Explanation | Condition
 --- | --- | ---
 ERROR_VALID_IP | Returns a list of the current network config. | Fails if no network config is found.
-ERROR_PING_SOUNDTRACK |  Checks connectivity to SYB internal endpoints in order for the product to work as expected | Fails if the player can't connect to any of these endpoints.
+ERROR_PING_SOUNDTRACK |  Checks connectivity to Soundtrack internal endpoints in order for the product to work as expected | Fails if the player can't connect to any of these endpoints.
 ERROR_PING_DNS | Check the DNS | Fails if DNS lookup doesn't work
 ERROR_PING_CDN | Checks connectivity to the CDN-servers in order for the product to download/stream music. | Fails if the player can't connect to the endpoints.
 ERROR_PING_CDN_IP | Checks connectivity rate to the CDN-servers in order for the product to have sufficient connectivity to guarantee download/stream music. | Fails if the player has a low success rate.
 ERROR_PING_CERT | Checks if a proxy is used. We do not support that. | Fails if proxy is found.
 ERROR_ONLINE_STATE | Checks online state | Fails if the player is offline/high amount of failing requests.
 ERROR_PAIRED | Checks if player is paired | Fails if not paired.
-ERROR_ACTIVE_SUBSCRIPTION | Checks if player have active subscription | Fails if inactive.
-ERROR_CHANNEL_ASSIGNED | Checks if any music is assigned | Fails if no music assigned
+ERROR_ACTIVE_SUBSCRIPTION | Checks if player have an active subscription | Fails if inactive.
+ERROR_CHANNEL_ASSIGNED | Checks if any source of music is assigned | Fails if no music is assigned
 ERROR_DOWNLOADED_DATA | Checks downloaded data for the assigned music. | Fails if nothing is downloaded.
-ERROR_NO_VOLUME | Checks the volume level | Fails if there is no volume, level is zero.
-ERROR_DISKCACHE_LOW | Checks free disk space | Fails if free disk space is below 1 GB.
-ERROR_DISKCACHE_CRITICALLY_LOW | Checks free disk space | Fails if free disk space is below 256 MB.
-ERROR_PAYMENT_EXPIRED | Check payment status | Fails if payment has expired.
-ERROR_CLOCK_WRONG | Check server time offset | Fails if server time offset differs +- 15 min
+ERROR_NO_VOLUME | Checks the volume level | Fails if there is volume is set to zero.
+ERROR_DISKCACHE_LOW | Checks free disk space | Fails if the free disk space is below 1 GB.
+ERROR_DISKCACHE_CRITICALLY_LOW | Checks free disk space | Fails if the free disk space is below 256 MB.
+ERROR_PAYMENT_EXPIRED | Check payment status | Fails if the paired zone doesn't have a valid and payed subscription.
+ERROR_CLOCK_WRONG | Check server time offset | Fails if server time offset differs +- 15 min from the device local time.
 
 ## Certification
 
@@ -252,8 +261,8 @@ ERROR_CLOCK_WRONG | Check server time offset | Fails if server time offset diffe
 * The certification process is developed from a customer experience standpoint. Ease of use is critical
 
 ### Definitions
-* **Pair** is Soundtrack lingo for connecting the Application with Soundtrack using the Device ID
-* **Device ID** is the Soundtrack generated ID needed for pairing the Application with Soundtrack's services
+* **Pair** is Soundtrack lingo for connecting the Application with Soundtrack
+* **Pairing code** is the Soundtrack generated code needed for pairing the Application with Soundtrack's services
 * **SDK** is the APIs and binaries provided by Soundtrack
 * **Application** is the partner built application that contains the SDK
 
@@ -268,9 +277,8 @@ Type | Test case | Instructions | Expected behavior
 --- | --- | --- | ---
 Setup | 1.1 | Start the device. | - The device should be intuitive to install and come with necessary instructions. - It should be simple to start the Application.
 . | 1.2 | Ensure Application has connectivity | Clearly stated whether or not the Application can access Soundtrack
-. | 1.3 | Find the device ID | - The device ID shall be easy to find. - If the device ID is generated in the Application, this generation should take less than one second. - The device ID shall not be generated more than once (not needed, since the request always will give the same response). - When creating the device ID, the correct label and description should be set. - Clearly stated what the device ID is used for and how to use it in order to connect the Application to Soundtrack. - The `label`-field used when creating the device shall be correct.
+. | 1.3 | Clear pairing flow | - The user entry point to initiate pairing should be clear and easily accessable for the user. - Clear user feedback if the pairing fails at any point in the flow should be present.
 . | 1.4 | Pair the Application in Soundtrack and assign a soundtrack | Music should start playing within 2 minutes.
-. | 1.5 | Ensure config variable `bandwidth_limitation_kbps` is set to at least 2000 kbps. | Music playing.
 Actions in [web interface](https://business.soundtrackyourbrand.com) | 2.1 | Skip track | Track skipped
 . | 2.2 | Press pause | Track paused
 . | 2.3 | Press play | Track resumed

--- a/sdk/index.md
+++ b/sdk/index.md
@@ -246,7 +246,7 @@ ERROR_PAIRED | Checks if player is paired | Fails if not paired.
 ERROR_ACTIVE_SUBSCRIPTION | Checks if player have an active subscription | Fails if inactive.
 ERROR_CHANNEL_ASSIGNED | Checks if any source of music is assigned | Fails if no music is assigned
 ERROR_DOWNLOADED_DATA | Checks downloaded data for the assigned music. | Fails if nothing is downloaded.
-ERROR_NO_VOLUME | Checks the volume level | Fails if there is volume is set to zero.
+ERROR_NO_VOLUME | Checks the volume level | Fails if the volume is set to zero.
 ERROR_DISKCACHE_LOW | Checks free disk space | Fails if the free disk space is below 1 GB.
 ERROR_DISKCACHE_CRITICALLY_LOW | Checks free disk space | Fails if the free disk space is below 256 MB.
 ERROR_PAYMENT_EXPIRED | Check payment status | Fails if the paired zone doesn't have a valid and payed subscription.

--- a/sdk/index.md
+++ b/sdk/index.md
@@ -249,7 +249,7 @@ ERROR_DOWNLOADED_DATA | Checks downloaded data for the assigned music. | Fails i
 ERROR_NO_VOLUME | Checks the volume level | Fails if the volume is set to zero.
 ERROR_DISKCACHE_LOW | Checks free disk space | Fails if the free disk space is below 1 GB.
 ERROR_DISKCACHE_CRITICALLY_LOW | Checks free disk space | Fails if the free disk space is below 256 MB.
-ERROR_PAYMENT_EXPIRED | Check payment status | Fails if the paired zone doesn't have a valid and payed subscription.
+ERROR_PAYMENT_EXPIRED | Check payment status | Fails if the paired zone doesn't have a valid and paid subscription.
 ERROR_CLOCK_WRONG | Check server time offset | Fails if server time offset differs +- 15 min from the device local time.
 
 ## Certification

--- a/sdk/index.md
+++ b/sdk/index.md
@@ -19,7 +19,7 @@ The Soundtrack SDK makes it possible to play music from Soundtrack on your platf
 It is available for selected partners with potential for over 5000 locations. 
 If you're interested in becoming one, please reach out to [sdk@soundtrackyourbrand.com](mailto:sdk@soundtrackyourbrand.com).
 
-All applications using the SDK must adhere to the Soundtrack Terms & Conditions. Certification is required before launch.
+All applications using the SDK must adhere to the Soundtrack Terms & Conditions. Certification of the integration is required before launch. Any non-trivial modification to the integration post-launch requires re-certification before it is released.
 
 ### API
 The SDK provides C header files, exposing an API called SPlayer API. It enables you to do basic playback control and interface to the audio output of your choice.


### PR DESCRIPTION
Fixes PLC-879

Updates the SDK documentation in general and specifically for promoting the use of paring code based auth over hard-pairing.